### PR TITLE
Remove arp timeout and decompose ip_to_arp table

### DIFF
--- a/ext/inception.py
+++ b/ext/inception.py
@@ -3,12 +3,12 @@ Inception Cloud SDN controller
 """
 
 from pox.core import core
-from pox.lib.packet.ethernet import ethernet
 from pox.lib.util import dpid_to_str
 from pox import log
 from pox.log import color
 import pox.openflow.libopenflow_01 as of
 from ext.inception_arp import InceptionArp
+from ext.inception_dhcp import InceptionDhcp
 
 LOGGER = core.getLogger()
 
@@ -25,24 +25,29 @@ class Inception(object):
     def __init__(self):
         core.openflow.addListeners(self)
         ## data stuctures
-        # dpid -> IP address: records the neighboring relationship
-        #between switches. It is mapping from data path ID (dpid) of a
-        #switch and IP address of neighboring rVM to port number. Its
-        #semantics is that each entry stands for connection between
-        #switches via some specific port. VXLan, however, only stores
-        #information of IP address of rVM in which neighbor switches
-        #lies.  Rather than storing the mapping from dpid to dpid
-        #directly, we store mapping from dpid to IP address. With
-        #further look-up in dpid_to_ip, the dpid to dpid mapping
-        #can be retrieved.
+        # MAC => (dpid, port): mapping from MAC address to (switch
+        # dpid, switch port) of end hosts
+        self.mac_to_dpid_port = {}
+        # dpid -> IP address: records the mapping from switch dpid) to
+        # IP address of the rVM where it resides. This table is to
+        # facilitate the look-up of dpid_ip_to_port
         self.dpid_to_ip = {}
-        # (dpid, IP address) -> port: records the mapping from data
-        #path ID (dpid) of a switch to IP address of the rVM where it
-        #resides. This table is to facilitate the look-up of
-        #dpid_ip_to_port.
+        # (dpid, IP address) -> port: records the neighboring
+        # relationship between switches. It is mapping from data path
+        # ID (dpid) of a switch and IP address of neighboring rVM to
+        # port number. Its semantics is that each entry stands for
+        # connection between switches via some specific port. VXLan,
+        # however, only stores information of IP address of rVM in
+        # which neighbor switches lies.  Rather than storing the
+        # mapping from dpid to dpid directly, we store mapping from
+        # dpid to IP address. With further look-up in dpid_to_ip, the
+        # dpid to dpid mapping can be retrieved.
         self.dpid_ip_to_port = {}
         ## modules
+        # ARP
         self.inception_arp = InceptionArp(self)
+        # DHCP
+        self.inception_dhcp = InceptionDhcp(self)
 
     def _handle_ConnectionUp(self, event):
         """
@@ -56,11 +61,10 @@ class Inception(object):
 
         # If the entry corresponding to the MAC already exists
         if switch_id in self.dpid_to_ip:
-            LOGGER.info("Switch=%s is already connected",
-                        dpid_to_str(switch_id))
+            LOGGER.info("switch=%s already connected", dpid_to_str(switch_id))
         else:
             self.dpid_to_ip[switch_id] = ip
-            LOGGER.info("Add: dpid=%s -> ip=%s", dpid_to_str(switch_id), ip)
+            LOGGER.info("Add: switch=%s -> ip=%s", dpid_to_str(switch_id), ip)
 
         # Collect port information.  Sift out ports connecting peer
         # switches and store them in dpid_ip_to_port
@@ -74,7 +78,7 @@ class Inception(object):
                 ip_suffix = ip_suffix.replace('-', '.')
                 peer_ip = '.'.join((IP_PREFIX, ip_suffix))
                 self.dpid_ip_to_port[(switch_id, peer_ip)] = port.port_no
-                LOGGER.info("Add: (dpid=%s, peer_ip=%s) -> port=%s",
+                LOGGER.info("Add: (switch=%s, peer_ip=%s) -> port=%s",
                             dpid_to_str(switch_id), peer_ip, port.port_no)
 
     def _handle_ConnectionDown(self, event):
@@ -90,24 +94,37 @@ class Inception(object):
         for key in self.dpid_ip_to_port.keys():
             (dpid, ip) = key
             if switch_id == dpid:
-                LOGGER.info("Del: (dpid=%s, peer_ip=%s) -> port=%s",
-                            dpid_to_str(dpid), ip,
-                            self.dpid_ip_to_port[key])
+                LOGGER.info("Del: (switch=%s, peer_ip=%s) -> port=%s",
+                            dpid_to_str(dpid), ip, self.dpid_ip_to_port[key])
                 del self.dpid_ip_to_port[key]
 
     def _handle_PacketIn(self, event):
         """
         Handle when a packet is received
         """
+        # If packet is not parsed properly, alert and return
         eth_packet = event.parsed
-        # If packet is not parsed properly, alert
         if not eth_packet.parsed:
             LOGGER.warning("Unparsable packet")
             return
 
-        # handle ARP packet
-        if eth_packet.type == ethernet.ARP_TYPE:
-            self.inception_arp.handle(event)
+        # do source learning
+        self._do_source_learning(event)
+        # handle ARP packet if it is
+        self.inception_arp.handle(event)
+        # handle DHCP packet if it is
+        self.inception_dhcp.handle(event)
+
+    def _do_source_learning(self, event):
+        """
+        Learn MAC => (switch dpid, switch port) mapping from a packet,
+        update self.mac_to_dpid_port table
+        """
+        eth_packet = event.parsed
+        if eth_packet.src not in self.mac_to_dpid_port:
+            self.mac_to_dpid_port[eth_packet.src] = (event.dpid, event.port)
+            LOGGER.info("Learn: host=%s -> (switch=%s, port=%s)",
+                        eth_packet.src, dpid_to_str(event.dpid), event.port)
 
     def setup_fwd_flows(self, dst_mac, switch_id, fwd_port,
                         peer_switch_id, peer_fwd_port):
@@ -119,14 +136,14 @@ class Inception(object):
             match=of.ofp_match(dl_dst=dst_mac),
             action=of.ofp_action_output(port=fwd_port),
             priority=FWD_PRIORITY))
-        LOGGER.info("Setup forwarding flow on switch=%s for dst_mac=%s",
+        LOGGER.info("Setup forward flow on switch=%s for dst_mac=%s",
                     dpid_to_str(switch_id), dst_mac)
         # The second flow at its peer switch
         core.openflow.sendToDPID(peer_switch_id, of.ofp_flow_mod(
             match=of.ofp_match(dl_dst=dst_mac),
             action=of.ofp_action_output(port=peer_fwd_port),
             priority=FWD_PRIORITY))
-        LOGGER.info("Setup forwarding flow on switch=%s for dst_mac=%s",
+        LOGGER.info("Setup forward flow on switch=%s for dst_mac=%s",
                     dpid_to_str(peer_switch_id), dst_mac)
 
 
@@ -136,4 +153,4 @@ def launch():
     log.launch(format="%(asctime)s - %(name)s - %(levelname)s - "
                "%(threadName)s - %(message)s")
     core.registerNew(Inception)
-    LOGGER.info("InceptionArp is running...")
+    LOGGER.info("InceptionArp is started...")


### PR DESCRIPTION
- arp does timeout any more
- ip_to_arp table becomes mac_to_dpid_port table in inception.py and
  ip_to_mac table in inception_arp.py
- Cleanup a bit of logger texts
