### PR TITLE
Fix bash bug

### DIFF
--- a/bin/inception_restore.sh
+++ b/bin/inception_restore.sh
@@ -8,10 +8,6 @@ BRIDGE_NAME=obr1
 # Deconnect from the controller
 sudo ovs-vsctl del-controller $BRIDGE_NAME
 
-# Set connection in-band. OVS will not install hidden flows
-# to ensure traditional functionality when the controller is down
-sudo ovs-vsctl set controller $BRIDGE_NAME connection-mode=in-band
-
 # Delete fail-mode. When connection to the controller is lost,
 # The virtual switch will act like a traditional switch
 sudo ovs-vsctl del-fail-mode $BRIDGE_NAME


### PR DESCRIPTION
Shall not set controller to be in-band
after deleting controller, as this would
cause "ovs-vsctl: no row "obr1" in table Controller"
